### PR TITLE
Build binary packages

### DIFF
--- a/.github/workflows/buildwheels.yml
+++ b/.github/workflows/buildwheels.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-11]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.14.1
+        # env:
+        #   CIBW_SOME_OPTION: value
+        #    ...
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+          config-file: "{package}/pyproject.toml"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+# For release, see:
+# https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml
+
+# Check this yaml with:
+# https://rhysd.github.io/actionlint/

--- a/.github/workflows/buildwheels.yml
+++ b/.github/workflows/buildwheels.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.14.1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-graft vendor/tree-sitter-*
+include menderbot/ext/my-languages.so

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft vendor/tree-sitter-*

--- a/README.md
+++ b/README.md
@@ -3,21 +3,26 @@
 ![Tests](https://github.com/craftvscruft/menderbot/actions/workflows/ci.yml/badge.svg?branch=main)
 [![License: APACHE](https://img.shields.io/github/license/craftvscruft/menderbot)](https://github.com/craftvscruft/menderbot/blob/main/LICENSE)
 
-> AI-powered command line tool for working with legacy code. Based on the principles of the [Mechanized Mending Manifesto](https://mender.ai/docs/intro).
+> The AI-powered command line tool for working with legacy code. Based on the principles of the [Mechanized Mending Manifesto](https://mender.ai/docs/intro).
+
+## Status
+
+Menderbot is usable in development of itself - a very small codebase. For instance, it's used on this project for first drafts of commit messages, it added most of the type annotations, and chat usually gives relevant answers. On codebases of an interesting size (> 10K lines) there is still much work to do.
 
 ## Commands implemented (-ish):
 
-* `menderbot ask`: Ask a question about a specific piece of code or concept
-* `menderbot chat`: Interactively chat in the context of the current directory
-* `menderbot commit`: Generate an informative commit message based on a changeset
+* `menderbot ask`: Ask a question about the codebase
+* `menderbot chat`: Interactively chat about the codebase
+* `menderbot commit`: Git commit the current changeset with a pre-populated commit message
 * `menderbot diff`: Summarize the differences between two versions of a codebase
 * `menderbot doc`: Generate documentation for the existing code (Python only)
 * `menderbot review`: Review a code block or changeset and provide feedback
 * `menderbot type`: Insert type hints (Python only)
-
+* `menderbot ingest`: Index the current state of the repo for `ask` and `chat` commands
 
 ## System requirements
 
+* git
 * [pipenv](https://pipenv.pypa.io/en/latest/) (for managing Python environments)
 * C Compiler
 * The environment variable `OPENAI_API_KEY` set to a valid OpenAI API Key.
@@ -37,7 +42,7 @@ pipenv shell
 ```
 ### Running
 
-While in the pipenv shell, install editable version.
+Install an editable version.
 ```
 python -m pip install -e .
 ```

--- a/menderbot/__init__.py
+++ b/menderbot/__init__.py
@@ -1,1 +1,3 @@
-VERSION = "0.0.1"  # Update README badge for new versions.
+__version__ = "0.0.1"  # Update README badge for new versions.
+
+from menderbot.__main__ import cli

--- a/menderbot/__main__.py
+++ b/menderbot/__main__.py
@@ -5,7 +5,7 @@ from rich.console import Console
 from rich.progress import Progress
 from rich.prompt import Confirm
 
-from menderbot import VERSION
+from menderbot import __version__
 from menderbot.check import run_check
 from menderbot.git_client import git_commit, git_diff_head
 from menderbot.ingest import ask_index, get_chat_engine, index_exists, ingest_repo
@@ -32,7 +32,7 @@ console = Console()
     default=False,
     help="Dry run, do not call API, only output prompts.",
 )
-@click.version_option(VERSION, prog_name="menderbot")
+@click.version_option(__version__, prog_name="menderbot")
 @click.pass_context
 def cli(ctx, debug, dry):
     """

--- a/menderbot/build_treesitter.py
+++ b/menderbot/build_treesitter.py
@@ -1,9 +1,10 @@
 from os.path import abspath, dirname, exists, join, pardir
 
+from setuptools.command.build import build  # type: ignore[import]
 from tree_sitter import Language
 
 ABS_DIRNAME = dirname(abspath(__file__))
-BUILD_DIR = abspath(join(ABS_DIRNAME, pardir, "build"))
+BUILD_DIR = abspath(join(ABS_DIRNAME, "ext"))
 VENDOR_DIR = abspath(join(ABS_DIRNAME, pardir, "vendor"))
 __TREE_SITTER_BINARY__ = join(BUILD_DIR, "my-languages.so")
 
@@ -28,6 +29,14 @@ def ensure_tree_sitter_binary() -> str:
         )
         build_tree_sitter_binary()
     return __TREE_SITTER_BINARY__
+
+
+class MyBuild(build):
+    """Used in setuptools cmdclass"""
+
+    def run(self):
+        build_tree_sitter_binary()
+        build.run(self)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["ai", "gpt", "refactoring", "legacy", "code"]
 dependencies = [
     "click >= 8.0.0",
     "rich-click >= 1.6.0",
-    "tree-sitter >= 0.20.1, < 0.21.0",
+    "tree-sitter >= 0.20.1, < 0.21.0", # match build-system version
     "charset-normalizer >= 3.2.0",
     "tiktoken",
     "llama-index >= 0.7.12",
@@ -40,35 +40,25 @@ dev = [
 Homepage = "https://github.com/craftvscruft/menderbot"
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0.0", "wheel", "tree-sitter >= 0.20.1, < 0.21.0"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]
-menderbot = "menderbot.__main__:cli"
+menderbot = "menderbot:cli"
 
 [tool.setuptools]
 packages = ["menderbot"]
+include-package-data = true # include MANIFEST.in
 
 [tool.setuptools.dynamic]
-version = {attr = "menderbot.VERSION"}
+version = {attr = "menderbot.__version__"}
+
+[tool.setuptools.cmdclass]
+build = "menderbot.build_treesitter.MyBuild"
 
 [tool.black]
 exclude = "vendor"
 
-[tool.bumpver]
-current_version = "2023.1001-alpha"
-version_pattern = "YYYY.BUILD[-TAG]"
-commit_message = "bump version {old_version} -> {new_version}"
-tag_message = "{new_version}"
-tag_scope = "default"
-commit = true
-tag = true
-push = true
-
-[tool.bumpver.file_patterns]
-"pyproject.toml" = [
-    'current_version = "{version}"',
-]
 "README.md" = [
     "{version}",
     "{pep440_version}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,46 @@
 [project]
 name = "menderbot"
 dynamic = ["version"]
+description = "The AI-powered command line tool for working with legacy code"
+readme = "README.md"
+authors = [{ name = "Ray Myers" }]
+license = { file = "LICENSE" }
+classifiers = [
+    "License :: OSI Approved :: Apache License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+]
+keywords = ["ai", "gpt", "refactoring", "legacy", "code"]
+dependencies = [
+    "click >= 8.0.0",
+    "rich-click >= 1.6.0",
+    "tree-sitter >= 0.20.1, < 0.21.0",
+    "charset-normalizer >= 3.2.0",
+    "tiktoken",
+    "llama-index >= 0.7.12",
+    "rich-click",
+    "gitpython"
+]
+requires-python = ">=3.9"
+
+[project.optional-dependencies]
+dev = [
+    "black", 
+    "bumpver", 
+    "isort", 
+    "pip-tools", 
+    "pytest",
+    "pylint",
+    "mypy",
+    "pre-commit",
+    "pytest-cov"
+]
+
+[project.urls]
+Homepage = "https://github.com/craftvscruft/menderbot"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]
@@ -17,3 +54,23 @@ version = {attr = "menderbot.VERSION"}
 
 [tool.black]
 exclude = "vendor"
+
+[tool.bumpver]
+current_version = "2023.1001-alpha"
+version_pattern = "YYYY.BUILD[-TAG]"
+commit_message = "bump version {old_version} -> {new_version}"
+tag_message = "{new_version}"
+tag_scope = "default"
+commit = true
+tag = true
+push = true
+
+[tool.bumpver.file_patterns]
+"pyproject.toml" = [
+    'current_version = "{version}"',
+]
+"README.md" = [
+    "{version}",
+    "{pep440_version}",
+]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,25 @@ menderbot = "menderbot:cli"
 [tool.setuptools]
 packages = ["menderbot"]
 include-package-data = true # include MANIFEST.in
+# zip-safe = false  # because of the uses of __file__
+platforms = [
+    'Linux',
+    'Mac OSX',
+    'Windows',
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "menderbot.__version__"}
 
 [tool.setuptools.cmdclass]
-build = "menderbot.build_treesitter.MyBuild"
+build_py = "menderbot.build_treesitter.BuildPy"
+bdist_wheel = "menderbot.build_treesitter.BdistWheel"
+
+[tool.distutils.bdist_wheel]
+universal = false
+
+[tool.cibuildwheel.linux]
+repair-wheel-command = "cp {wheel} {dest_dir}" # auditwheel mistakes us for a purelib and won't allow .so
 
 [tool.black]
 exclude = "vendor"


### PR DESCRIPTION
Build platform-specific binary packages, including compiled tree-sitter parser.

- Add a new GitHub workflow `buildwheels.yml` for building wheels for Ubuntu, Windows, and MacOS
- Include project manifest `MANIFEST.in` to add `my-languages.so` from `menderbot/ext`
- Update `README.md`
- Change the version variable in `menderbot/__init__.py` from `VERSION` to `__version__`
- Update `menderbot/build_treesitter.py` to:
  - Change `BUILD_DIR` to point to `ext` directory inside `menderbot`
  - Add a new class `MyBuild` that builds tree sitter binary, called during wheel build
- Update `pyproject.toml` to:
  - Add project metadata
  - Update the build system requirements
  - Change the script for `menderbot` to point to `cli` in `menderbot`
  - Add a command class `build` that points to `MyBuild` in `menderbot.build_treesitter`
  - Add a section for `tool.black` to exclude the `vendor` directory